### PR TITLE
passwordカラムを削除しました。

### DIFF
--- a/src/database/migrations/2024_01_25_021457_drop_column_password_column.php
+++ b/src/database/migrations/2024_01_25_021457_drop_column_password_column.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //passwordカラムを削除
+            $table->dropColumn('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //passwordカラムを追加
+            $table->string('password');
+        });
+    }
+};


### PR DESCRIPTION
passwordカラムのみの削除です。そのほかのカラムについては残してあります。
現在のusersテーブルの構造
id('user_id');|`string('name');`|`string('email')->unique();`|'timestamp('email_verified_at')->nullable();'|'rememberToken();'|`timestamps();`